### PR TITLE
Improvement: pokud selže changeEntityState po callbacku, zalogovat příčinu a ukončit

### DIFF
--- a/src/Queue.php
+++ b/src/Queue.php
@@ -97,10 +97,17 @@ class Queue extends \Nette\Object {
 
 		} catch (\Exception $e) {
 
-			// kritická chyba
-			$this->changeEntityState($entity, Entity\QueueEntity::STATE_ERROR_FATAL, $e->getMessage());
+			try {
+				// kritická chyba
+				$this->changeEntityState($entity, Entity\QueueEntity::STATE_ERROR_FATAL, $e->getMessage());
+			} catch (\Exception $innerEx) {
+				// může nastat v případě, kdy v callbacku selhal např. INSERT a entity manager se uzavřel
 
-			// odeslání emailu o chybě
+				// odeslání emailu o nemožnosti uložit chybu do DB
+				\Tracy\Debugger::log($innerEx, \Tracy\ILogger::CRITICAL);
+			}
+
+			// odeslání emailu o chybě v callbacku
 			\Tracy\Debugger::log($e, \Tracy\ILogger::EXCEPTION);
 		}
 


### PR DESCRIPTION
Může nastat v případě, kdy v callbacku selhal např. INSERT a entity manager se uzavřel. ChangeEntityState pak vyhodí výjimku dřív, než se stihne poslat email o nepovedeném INSERTu.

V log složce pak skončí `Entity manager is closed` a do DB se nic neuloží, takže nejde zjistit, kde je vlastně příčina.

Nově se 

1. zaloguje chyba `Integrity constraint violation: 1048 Column 'user_id' cannot be null`,
2. job se vrátí do error fronty,
3. zaloguje chyba `Entity manager is closed`,
4. consumer se ukončí (nemá smysl, aby běžel dál).