### PR TITLE
Ability to reload all consumers

### DIFF
--- a/src/Console/BackgroundQueueCommand.php
+++ b/src/Console/BackgroundQueueCommand.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 
 /**
+ * @see \ADT\BackgroundQueue\Queue::processRepeatableErrors
  */
 class BackgroundQueueCommand extends Command {
 
@@ -21,6 +22,7 @@ class BackgroundQueueCommand extends Command {
 				InputArgument::IS_ARRAY,
         'Názvy callbacků (oddělené mezerou)'
     );
+		$this->setDescription('Zavolá callback pro všechny záznamy z DB s nastaveným stavem STATE_ERROR_FATAL.');
 	}
 
 	/**

--- a/src/Console/BackgroundQueueConsumerReloadCommand.php
+++ b/src/Console/BackgroundQueueConsumerReloadCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace ADT\BackgroundQueue\Console;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+/**
+ * Vytvoří několik (dle konfigurace) noop operací, aby každý consumer zkontroloval, zda se nemá ukončit.
+ */
+class BackgroundQueueConsumerReloadCommand extends Command {
+
+	/**
+	 * @var array
+	 */
+	protected $config;
+
+	/** @var \ADT\BackgroundQueue\Service */
+	protected $queueService;
+
+	public function setConfig($config) {
+		$this->config = $config;
+	}
+
+	protected function configure() {
+		$this->setName('adt:backgroundQueue:consumerReload');
+		$this->setDescription('Vytvoří několik (dle konfigurace) noop operací, aby každý consumer zkontroloval, zda se nemá ukončit.');
+	}
+
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 */
+	protected function initialize(InputInterface $input, OutputInterface $output) {
+		$this->queueService = $this->getHelper('container')->getByType(\ADT\BackgroundQueue\Service::class);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+
+		foreach (range(1, $this->config['supervisor']['numprocs']) as $i) {
+			$this->queueService->publishNoop();
+		}
+
+		$output->writeln("SUCCESS");
+	}
+
+}

--- a/src/DI/BackgroundQueueExtension.php
+++ b/src/DI/BackgroundQueueExtension.php
@@ -7,8 +7,12 @@ class BackgroundQueueExtension extends \Nette\DI\CompilerExtension {
 	public function loadConfiguration() {
 		$builder = $this->getContainerBuilder();
 		$config = $this->validateConfig([
-			"callbacks" => [],
-			"queueEntityClass" => \ADT\BackgroundQueue\Entity\QueueEntity::class,
+			'callbacks' => [],
+			'queueEntityClass' => \ADT\BackgroundQueue\Entity\QueueEntity::class,
+			'noopMessage' => 'noop',
+			'supervisor' => [
+				'numprocs' => 1,
+			],
 		]);
 
 		// registrace queue service
@@ -19,13 +23,26 @@ class BackgroundQueueExtension extends \Nette\DI\CompilerExtension {
 		// registrace service
 		$builder->addDefinition($this->prefix('service'))
 			->setClass(\ADT\BackgroundQueue\Service::class)
-			->addSetup('$service->setCallbackKeys(?)', [array_keys($config["callbacks"])]);
+			->addSetup('$service->setConfig(?)', [
+				[
+					'callbackKeys' => array_keys($config["callbacks"]),
+					'noopMessage' => $config['noopMessage'],
+				],
+			]);
 
-		// registrace commandu
+		// registrace commandů
+
 		$builder->addDefinition($this->prefix('command'))
 			->setClass(\ADT\BackgroundQueue\Console\BackgroundQueueCommand::class)
 			->setInject(FALSE)
 			->addTag('kdyby.console.command');
+
+		$builder->addDefinition($this->prefix('consumerReloadCommand'))
+			->setClass(\ADT\BackgroundQueue\Console\BackgroundQueueConsumerReloadCommand::class)
+			->addSetup('$service->setConfig(?)', [$config])
+			->setInject(FALSE)
+			->addTag('kdyby.console.command');
+
 	}
 
 }

--- a/src/Service.php
+++ b/src/Service.php
@@ -11,7 +11,7 @@ class Service extends \Nette\Object {
 	protected $em;
 
 	/** @var array */
-	protected $callbackKeys = [];
+	protected $config;
 
 	/** @var array */
 	public $onShutdown = [];
@@ -31,10 +31,10 @@ class Service extends \Nette\Object {
 	}
 
 	/**
-	 * @param array $callbackKeys
+	 * @param array $config
 	 */
-	public function setCallbackKeys(array $callbackKeys) {
-		$this->callbackKeys = $callbackKeys;
+	public function setConfig(array $config) {
+		$this->config = $config;
 	}
 
 	/**
@@ -49,7 +49,7 @@ class Service extends \Nette\Object {
 			throw new \Exception("Entita nemá nastavený povinný parametr \"callbackName\".");
 		}
 
-		if (!in_array($entity->getCallbackName(), $this->callbackKeys)) {
+		if (!in_array($entity->getCallbackName(), $this->config['callbackKeys'])) {
 			throw new \Exception("Neexistuje callback \"" . $entity->getCallbackName() . "\".");
 		}
 
@@ -63,5 +63,16 @@ class Service extends \Nette\Object {
 			$producer->publish($entity->getId());
 		};
 	}
+
+	/**
+	 * Publikuje No-operation zprávu do fronty.
+	 */
+	public function publishNoop() {
+
+		// odeslání do RabbitMQ
+		$producer = $this->bunny->getProducer('generalQueue');
+		$producer->publish($this->config['noopMessage']);
+	}
+
 
 }


### PR DESCRIPTION
New command, which sends several noop messages. You can send SIGINT to all of the consumers and then run adt:backgroundQueue:consumerReload command. All of the consumers are not interrupted in the middle of process, but they end after they process their current task.