### PR TITLE
Ability to reload all consumers

### DIFF
--- a/src/Console/BackgroundQueueConsumerReloadCommand.php
+++ b/src/Console/BackgroundQueueConsumerReloadCommand.php
@@ -39,9 +39,7 @@ class BackgroundQueueConsumerReloadCommand extends Command {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 
-		foreach (range(1, $this->config['supervisor']['numprocs']) as $i) {
-			$this->queueService->publishNoop();
-		}
+		$this->queueService->publishSupervisorNoop();
 
 		$output->writeln("SUCCESS");
 	}

--- a/src/DI/BackgroundQueueExtension.php
+++ b/src/DI/BackgroundQueueExtension.php
@@ -15,20 +15,24 @@ class BackgroundQueueExtension extends \Nette\DI\CompilerExtension {
 			],
 		]);
 
+		if ($config['supervisor']['numprocs'] <= 0) {
+			throw new \Nette\Utils\AssertionException('Hodnota configu %supervisor.numprocs% musí být kladné číslo');
+		}
+
 		// registrace queue service
 		$builder->addDefinition($this->prefix('queue'))
 			->setClass(\ADT\BackgroundQueue\Queue::class)
 			->addSetup('$service->setConfig(?)', [$config]);
 
+		// Z `callbacks` nepředáváme celé servisy ale pouze klíče, protože nic víc nepotřebujeme a měli bychom zbytečnou závislost.
+		$serviceConfig = $config;
+		unset($serviceConfig['callbacks']);
+		$serviceConfig['callbackKeys'] = array_keys($config["callbacks"]);
+
 		// registrace service
 		$builder->addDefinition($this->prefix('service'))
 			->setClass(\ADT\BackgroundQueue\Service::class)
-			->addSetup('$service->setConfig(?)', [
-				[
-					'callbackKeys' => array_keys($config["callbacks"]),
-					'noopMessage' => $config['noopMessage'],
-				],
-			]);
+			->addSetup('$service->setConfig(?)', [$serviceConfig]);
 
 		// registrace commandů
 

--- a/src/Service.php
+++ b/src/Service.php
@@ -74,5 +74,15 @@ class Service extends \Nette\Object {
 		$producer->publish($this->config['noopMessage']);
 	}
 
+	/**
+	 * Publikuje No-operation zprávu do fronty.
+	 */
+	public function publishSupervisorNoop() {
+
+		for ($i = 0; $i < $this->config['supervisor']['numprocs']; $i++) {
+			$this->publishNoop();
+		}
+	}
+
 
 }


### PR DESCRIPTION
Logic moved into Service::publishSupervisorNoop, so we can use it beside the command.