### PR TITLE
upravit-rabbitmq-komponentu-aby-pri-urcitem-mnozstvi-neuspesnych-poku…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ backgroundQueue:
 		numprocs: 1	# Počet consumerů
 		startsecs: 1	# [sec] - Jedno zpracování je případně uměle protaženo sleepem, aby si *supervisord* nemyslel, že se proces ukončil moc rychle
 	lazy: TRUE	# Lazy callbacky (viz další kapitolu)
+	numberOfAttemptsForMail: 5 # počet pokusů zpracování fronty pro zaslání mailu
 	callbacks:
 		test: @App\Facades::process
 		...

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ backgroundQueue:
 		numprocs: 1	# Počet consumerů
 		startsecs: 1	# [sec] - Jedno zpracování je případně uměle protaženo sleepem, aby si *supervisord* nemyslel, že se proces ukončil moc rychle
 	lazy: TRUE	# Lazy callbacky (viz další kapitolu)
-	numberOfAttemptsForMail: 5 # počet pokusů zpracování fronty pro zaslání mailu
+	notifyOnNumberOfAttempts: 5 # počet pokusů zpracování fronty pro zaslání mailu
 	callbacks:
 		test: @App\Facades::process
 		...

--- a/src/DI/BackgroundQueueExtension.php
+++ b/src/DI/BackgroundQueueExtension.php
@@ -18,7 +18,7 @@ class BackgroundQueueExtension extends \Nette\DI\CompilerExtension {
 				'numprocs' => 1,
 				'startsecs' => 1, // [sec]
 			],
-			'numberOfAttemptsForMail' => 5, // počet pokusů zpracování fronty pro zaslání mailu
+			'notifyOnNumberOfAttempts' => 5, // počet pokusů zpracování fronty pro zaslání mailu
 		]);
 
 		if ($config['supervisor']['numprocs'] <= 0) {

--- a/src/DI/BackgroundQueueExtension.php
+++ b/src/DI/BackgroundQueueExtension.php
@@ -18,6 +18,7 @@ class BackgroundQueueExtension extends \Nette\DI\CompilerExtension {
 				'numprocs' => 1,
 				'startsecs' => 1, // [sec]
 			],
+			'numberOfAttemptsForMail' => 5, // počet pokusů zpracování fronty pro zaslání mailu
 		]);
 
 		if ($config['supervisor']['numprocs'] <= 0) {

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -184,6 +184,10 @@ class Queue {
 		// Zprávu pošleme do fronty "generalQueueError", kde zpráva zůstane 20 minut (nastavuje se v neonu)
 		// a po 20 minutách se přesune zpět do fronty "generalQueue" a znovu se zpracuje
 		if ($output === FALSE) {
+
+			if ($entity->numberOfAttempts == $this->config["numberOfAttemptsForMail"]) { // pri urcitem mnozstvi neuspesnych pokusu posilat email
+				\Tracy\Debugger::log("BackgroundQueue: Počet pokusů již dosáhl " .$entity->numberOfAttempts." pokusů, ID " . $entity->getId(),\Tracy\ILogger::ERROR);
+			}
 			$this->service->publish($entity, 'generalQueueError');
 		}
 

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -185,8 +185,8 @@ class Queue {
 		// a po 20 minutách se přesune zpět do fronty "generalQueue" a znovu se zpracuje
 		if ($output === FALSE) {
 
-			if ($entity->numberOfAttempts == $this->config["numberOfAttemptsForMail"]) { // pri urcitem mnozstvi neuspesnych pokusu posilat email
-				\Tracy\Debugger::log("BackgroundQueue: Počet pokusů již dosáhl " .$entity->numberOfAttempts." pokusů, ID " . $entity->getId(),\Tracy\ILogger::ERROR);
+			if ($entity->numberOfAttempts == $this->config["notifyOnNumberOfAttempts"]) { // pri urcitem mnozstvi neuspesnych pokusu posilat email
+				\Tracy\Debugger::log("BackgroundQueue: Number of attempts reached " .$entity->numberOfAttempts.", ID " . $entity->getId(), \Tracy\ILogger::ERROR);
 			}
 			$this->service->publish($entity, 'generalQueueError');
 		}


### PR DESCRIPTION
…su-zaslala-email

[KNT] Upravit RabbitMQ komponentu, aby pri urcitem mnozstvi neuspesnych pokusu zaslala email

https://trello.com/c/gPXFSum6/2178-knt-upravit-rabbitmq-komponentu-aby-pri-urcitem-mnozstvi-neuspesnych-pokusu-zaslala-email

jeden od kazdeho typu callbacku
pocet neuspesnsch pokusu umoznit nastavit v aplikaci, ale defaultne dat 5