### PR TITLE
BUG

### DIFF
--- a/src/BackgroundQueue.php
+++ b/src/BackgroundQueue.php
@@ -259,7 +259,7 @@ class BackgroundQueue
 		$this->em->flush();
 	}
 
-	private static function logException(string $errorMessage, ?BackgroundJob $entity = null, ?Exception $e = null): void
+	private static function logException(string $errorMessage, ?BackgroundJob $entity = null, ?Throwable $e = null): void
 	{
 		Debugger::log(new Exception('BackgroundQueue: ' . $errorMessage  . ($entity ? ' (ID: ' . $entity->getId() . '; State: ' . $entity->getState() . ')' : ''), 0, $e), ILogger::CRITICAL);
 	}


### PR DESCRIPTION
ADT\BackgroundQueue\BackgroundQueue::logException(): Argument #3 ($e) must be of type ?Exception, TypeError given, called in /var/www/html/vendor/adt/background-queue/src/BackgroundQueue.php on line 152