### PR TITLE
BackgroundJob::$parameters - fix for PostgreSQL

### DIFF
--- a/src/Entity/BackgroundJob.php
+++ b/src/Entity/BackgroundJob.php
@@ -133,6 +133,8 @@ final class BackgroundJob
 	 */
 	public function getParameters(): array
 	{
+		$this->parameters = is_resource($this->parameters) ? stream_get_contents($this->parameters) : $this->parameters;
+		
 		if (substr($this->parameters, 0, 2) === 'a:') {
 			return unserialize($this->parameters);
 		}


### PR DESCRIPTION
PostgreSQL do convert blob into resource instead of into string