### PR TITLE
Fixes schema generation lock directory

### DIFF
--- a/src/BackgroundQueue.php
+++ b/src/BackgroundQueue.php
@@ -430,7 +430,9 @@ class BackgroundQueue
 	 */
 	public function createQueryBuilder(): QueryBuilder
 	{
-		$this->updateSchema();
+		if ($this->config['autoUpdateSchema']) {
+			$this->updateSchema();
+		}
 
 		return $this->connection->createQueryBuilder()
 			->select('*')
@@ -551,7 +553,9 @@ class BackgroundQueue
 	public function save(BackgroundJob $entity): void
 	{
 		$this->databaseConnectionCheckAndReconnect();
-		$this->updateSchema();
+		if ($this->config['autoUpdateSchema']) {
+			$this->updateSchema();
+		}
 
 		if (!$entity->getId()) {
 			if ($this->producer) {
@@ -669,12 +673,8 @@ class BackgroundQueue
 	 * @throws Exception
 	 * @internal
 	 */
-	public function updateSchema(bool $force = false, bool $ignoreAutoUpdateSchema = false): void
+	public function updateSchema(bool $force = false): void
 	{
-		if (!$ignoreAutoUpdateSchema && !$this->config['autoUpdateSchema']) {
-			return;
-		}
-
 		if (!$force && !FileSystem::createDirAtomically($this->config['locksDir'] . '/background_queue_schema_generated')) {
 			return;
 		}

--- a/src/BackgroundQueue.php
+++ b/src/BackgroundQueue.php
@@ -672,7 +672,11 @@ class BackgroundQueue
 	 */
 	public function updateSchema(bool $force = false): void
 	{
-		if (!$force && !FileSystem::createDirAtomically($this->config['tempDir'] . '/background_queue_schema_generated')) {
+		if (!$this->config['autoUpdateSchema']) {
+			return;
+		}
+
+		if (!$force && !FileSystem::createDirAtomically($this->config['locksDir'] . '/background_queue_schema_generated')) {
 			return;
 		}
 

--- a/src/BackgroundQueue.php
+++ b/src/BackgroundQueue.php
@@ -672,7 +672,7 @@ class BackgroundQueue
 	 */
 	public function updateSchema(bool $force = false): void
 	{
-		if (!$force && !FileSystem::createDirAtomically($this->config['locksDir'] . '/background_queue_schema_generated')) {
+		if (!$force && !FileSystem::createDirAtomically($this->config['tempDir'] . '/background_queue_schema_generated')) {
 			return;
 		}
 

--- a/src/BackgroundQueue.php
+++ b/src/BackgroundQueue.php
@@ -39,7 +39,6 @@ class BackgroundQueue
 	private array $bulkBrokerCallbacks = [];
 	private array $bulkDatabaseEntities = [];
 	private bool $shouldDie = false;
-	private EventManager $eventManager;
 
 	/**
 	 * @throws Exception
@@ -670,9 +669,9 @@ class BackgroundQueue
 	 * @throws Exception
 	 * @internal
 	 */
-	public function updateSchema(bool $force = false): void
+	public function updateSchema(bool $force = false, bool $ignoreAutoUpdateSchema = false): void
 	{
-		if (!$this->config['autoUpdateSchema']) {
+		if (!$ignoreAutoUpdateSchema && !$this->config['autoUpdateSchema']) {
 			return;
 		}
 

--- a/src/Console/UpdateSchemaCommand.php
+++ b/src/Console/UpdateSchemaCommand.php
@@ -38,7 +38,7 @@ class UpdateSchemaCommand extends Command
 	 */
 	protected function executeCommand(InputInterface $input, OutputInterface $output): int
 	{
-		$this->backgroundQueue->updateSchema($input->getOption('force'), ignoreAutoUpdateSchema: true);
+		$this->backgroundQueue->updateSchema($input->getOption('force'));
 
 		return 0;
 	}

--- a/src/Console/UpdateSchemaCommand.php
+++ b/src/Console/UpdateSchemaCommand.php
@@ -34,10 +34,11 @@ class UpdateSchemaCommand extends Command
 	/**
 	 * @throws SchemaException
 	 * @throws Exception
+	 * @throws \Doctrine\DBAL\Exception
 	 */
 	protected function executeCommand(InputInterface $input, OutputInterface $output): int
 	{
-		$this->backgroundQueue->updateSchema($input->getOption('force'));
+		$this->backgroundQueue->updateSchema($input->getOption('force'), ignoreAutoUpdateSchema: true);
 
 		return 0;
 	}


### PR DESCRIPTION
The schema generation lock directory was incorrectly set to the locks directory instead of the temp directory. This commit updates the path to ensure the lock is created in the correct location.